### PR TITLE
make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 images_names=kodim01.png kodim02.png
 
-all: split
-images:$(addprefix testImage/,$(images_names))
-.PHONY: clean test
-
-BINS=split tests/createBlankImage
+PREFIX ?= /usr/local
+PROG=split
+BINS=${PROG} tests/createBlankImage
 OBJ:=split.o lib/fillwithblack.o lib/manppm.o
 EXTRACFLAGS=
 CFLAGS=-Wall $(EXTRACFLAGS)
 
+all: ${PROG}
+images:$(addprefix testImage/,$(images_names))
+.PHONY: clean test
+
 $(BINS):
 	$(CC) $(CFLAGS) -lm -o $@ $^
 
-split: $(OBJ)
+${PROG}: $(OBJ)
 tests/createBlankImage: tests/createBlankImage.o lib/fillwithblack.o lib/manppm.o
 
 
@@ -20,9 +22,10 @@ testImage/kodim%.png:
 	wget --quiet http://r0k.us/graphics/kodak/kodak/$(notdir $@) -O $@
 
 clean:
-	rm -f $(OBJ) split tests/createBlankImage
+	rm -f $(OBJ) ${PROG} tests/createBlankImage
 
-
-
-test: tests/cuttest tests/createBlankImage split
+test: tests/cuttest tests/createBlankImage ${PROG}
 	cd $(dir $<) && bash $(notdir $<)
+
+install:
+	@install -Dm755 ${PROG} ${DESTDIR}/${PREFIX}/bin/${PROG}


### PR DESCRIPTION
With a `make install` ready working, it is easier to:
- create packages
- install it system-wide
